### PR TITLE
ci: use ncu --peer instead of exclude lists

### DIFF
--- a/.github/workflows/update-functions.yml
+++ b/.github/workflows/update-functions.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: npm update
         run: |
-          npx npm-check-updates -u -x typescript,firebase-admin
+          npx npm-check-updates -u --peer
           npm install -f
           npm update
           npm install

--- a/.github/workflows/update-shared.yml
+++ b/.github/workflows/update-shared.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: npm update
         run: |
-          npx npm-check-updates -u -x typescript
+          npx npm-check-updates -u --peer
           npm install -f
           npm update
           npm install

--- a/.github/workflows/update-web.yml
+++ b/.github/workflows/update-web.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: npm update
         run: |
-          npx npm-check-updates -u -x typescript
+          npx npm-check-updates -u --peer
           npm install -f
           npm update
           npm install


### PR DESCRIPTION
## What
Replace `npm-check-updates -u -x <pins>` with `npm-check-updates -u --peer` in the dependency-update workflow(s).

## Why
`ncu -u` resolves each package's latest version in isolation, ignoring peer-dependency ranges. It bumped packages past what the framework allows (vitest 4→5 under @angular/build@22; typescript →6/7 under @typescript-eslint@8), so the single `npm install` failed with ERESOLVE and produced no update PR.

`--peer` makes ncu honor the peer deps of installed packages, holding back exactly the packages that would conflict — and only for as long as the conflict exists. This replaces the manual `-x` exclude lists, which had to be remembered and later un-pinned by hand.

## Note
Dropping the exclude lists also unpins eslint / firebase-admin / firebase-functions / zone.js. `--peer` still holds zone.js and typescript (Angular peer-requires them); eslint and firebase-* majors will now surface as normal, reviewable update PRs instead of being silently skipped.

Generated by Alfred while fixing the ERESOLVE failures in the update workflows.